### PR TITLE
docs: Correct install instruction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Example playbook:
     aws_base_rds_dbtype: postgres
 
   roles:
-    - role: stackbuilders.aws-base
+    - role: stackbuilders.aws_base
 ```
 
 ## Role Variables

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Generic AWS resource provisioning.
 Install Ansible role:
 
 ```sh
-ansible-galaxy install stackbuilders.aws-base
+ansible-galaxy install stackbuilders.aws_base
 ```
 
 Example playbook:


### PR DESCRIPTION
Install instruction with hyphenated name doesn't work (at least on ansible-galaxy version 2.9.2).

This change corrects it to an underscored name.