### PR TITLE
fix: Correct the name of the keypair variable.

### DIFF
--- a/tasks/ec2/keypairs.yml
+++ b/tasks/ec2/keypairs.yml
@@ -13,6 +13,6 @@
   register: stat_key
 
 - name: "Copy private key"
-  copy: content="{{ aws_mngt_keypair.key.private_key }}" dest="{{ aws_keypair }}.pem" mode=0400
+  copy: content="{{ aws_mngt_keypair.key.private_key }}" dest="{{ aws_base_keypair }}.pem" mode=0400
   delegate_to: localhost
   when: aws_mngt_keypair.changed


### PR DESCRIPTION
The name of the variable used in dest was incorrect and prevented the role from running. This change corrects that variable name.