### PR TITLE
feat: Lookup base ec2 ami when not supplied.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,6 @@ at run time:
 AWS_PROFILE=project ansible-playbook playbooks/myplaybook.yml
 ```
 
-**NOTE:** We MUST set the `aws_ec2_ami` value like the following as this
-depends on the region:
-
-```sh
-aws_ec2_ami: ami-09d31fc66dcb58522
-```
-
 ## License
 
 MIT, see the [LICENSE](LICENSE) file in this repository.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,4 +42,7 @@ aws_ec2_type_tag: servers
 aws_ec2_volume_size: "20"
 
 # RDS definitions
-aws_rds_instance_type: db.t2.micro
+aws_base_rds_instance_type: db.t2.micro
+
+# AWS SSM key to use if aws_base_ec2_ami is not set
+aws_base_ec2_ami_lookup_key: /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2

--- a/tasks/ec2/instances.yml
+++ b/tasks/ec2/instances.yml
@@ -7,6 +7,11 @@
       instance-state-name: running
   register: ec2_servers_state
 
+- name: "Lookup ec2 ami ssm parameter"
+  set_fact:
+    aws_base_ec2_ami: "{{ lookup('aws_ssm', aws_base_ec2_ami_lookup_key, region=aws_base_region) }}"
+  when: aws_base_ec2_ami is not defined and ec2_servers_state['instances'] |list |count == 0
+
 - name: "Getting VPC id... "
   ec2_vpc_net_info:
     aws_region: "{{ aws_region }}"


### PR DESCRIPTION
Currently, the aws_base_ec2_ami value must be found and supplied manually to ensure the image exists in the region.

This change removes that requirement by doing a lookup against the AWS parameter store public parameters which provide the appropriate base image for the region.